### PR TITLE
fix incompatible go version in older Ubuntu (ex. 16.04)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,7 @@ else
       echo PROCEEDING...
 fi
 
-sudo go build -o $GOPATH/bin/pocket ./app/cmd/pocket_core/main.go
+go build -o $GOPATH/bin/pocket ./app/cmd/pocket_core/main.go
 
 sleep 2
 if [[ "$M_T_NETWORK" == "M" ]]; then


### PR DESCRIPTION
hi, I noticed that this particular line:
```base
sudo go build -o $GOPATH/bin/pocket ./app/cmd/pocket_core/main.go
```
would fail on older Ubuntu (ex. 16.04) because the system go version is too old 1.10

was able to fix it by simply removing the `sudo` so it uses the newer go version installed per README